### PR TITLE
fix: 修正钢叶第12级升级描述错字

### DIFF
--- a/js/layers.js
+++ b/js/layers.js
@@ -33874,7 +33874,7 @@ addLayer("crafting_table", {
                 需要工具：工厂环 + 铅锤<br>
                 需要材料：${f(6.6686e33)}炽铁锭 + 2钻石奇点（不消耗）<br>
                 复杂度：${formatWhole(this.complexity)}<br>
-                效果：你对九头蛇和暮初恶魂带有4x；对冰雪女王带有1.667x的特攻，冰雪女王的冻结将不影响你的DEF<br>`
+                效果：你对九头蛇和暮初恶魂带有4x特攻；对冰雪女王带有1.667x特攻，冰雪女王的冻结将不影响你的DEF<br>`
                 return d
             },
             complexity: d(1.796e25),

--- a/js/layers.js
+++ b/js/layers.js
@@ -24907,7 +24907,7 @@ addLayer("steeleaf", {
         },
         32: {
             title: "不只是御寒",
-            description() { return `雪怪首领毛皮加成装甲碎片堆获取，且装甲碎片堆的合成倍率锁定为装甲碎片的1%，骑士金属锭熔炼倍率为装甲碎片堆的10%` },
+            description() { return `雪怪首领毛皮加成装甲碎片获取，且装甲碎片堆的合成倍率锁定为装甲碎片的1%，骑士金属锭熔炼倍率为装甲碎片堆的10%` },
             cost() { return new ExpantaNum(1.111e111) },
             unlocked() { return hasUpgrade(this.layer, this.id - 1) },
             effect() {


### PR DESCRIPTION
#### 修复内容
修正钢叶第12升级“不只是御寒”中错误文本：
- 原文本：雪怪首领毛皮加成装甲碎片堆获取
- 修正后：雪怪首领毛皮加成装甲碎片获取

#### 关联Issue
Fixes #4